### PR TITLE
Heroku triangle + hot reloading

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start:prod

--- a/client/package.json
+++ b/client/package.json
@@ -30,5 +30,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:8080/"
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,9 +13,9 @@ class getPostgres extends React.Component {
     }
 
     handleClick() {
-        axios.get(`/test`)
+        axios.get(`/test-db`)
             .then(res => {
-                console.log('componentDidMount: axios.get(/test).then');
+                console.log('componentDidMount: axios.get(/test-db).then');
                 console.log(res.data);
                 const persons = res.data;
                 this.setState({
@@ -23,7 +23,6 @@ class getPostgres extends React.Component {
                 });
         })
     }
-
 
 
     render() {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,7 +9,7 @@ class getPostgres extends React.Component {
         super(props);
         this.state = { persons: ['placeholder name'] }
 
-        this.handleClick = this.handleClick.bind(this); 
+        this.handleClick = this.handleClick.bind(this);
     }
 
     handleClick() {
@@ -24,7 +24,7 @@ class getPostgres extends React.Component {
         })
     }
 
-    
+
 
     render() {
         return (

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -1,13 +1,18 @@
 const { Client } = require('pg');
 
-const client = new Client({
-    user: process.env.PG_LOCAL_USER,
-    host: process.env.PG_LOCAL_HOST,
-    database: process.env.PG_LOCAL_DATABASE,
-    port: process.env.PG_LOCAL_PORT
-});
+let client;
+if (process.env.NODE_ENV === 'production') {
+    console.log("prod: skipping connecting to production DB for now");
+} else {
+    client = new Client({
+        user: process.env.PG_LOCAL_USER,
+        host: process.env.PG_LOCAL_HOST,
+        database: process.env.PG_LOCAL_DATABASE,
+        port: process.env.PG_LOCAL_PORT
+    });
+    client.connect();
+}
 
-client.connect();
 
 function query(text) {
     return client.query(text);

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "",
   "main": "start.js",
   "scripts": {
-    "start": "npm run start:dev",
+    "build": "cd client && npm run build",
+    "start": "cd client && npm start",
+    "server": "npm run start:dev",
     "start:dev": "NODE_ENV=dev node start.js",
     "start:prod": "node start.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "heroku-postbuild": "cd client && npm install && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "start.js",
   "scripts": {
-    "start": "NODE_ENV=dev node start.js",
+    "start": "npm run start:dev",
+    "start:dev": "NODE_ENV=dev node start.js",
+    "start:prod": "node start.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,6 +2,9 @@ var express = require('express')
 var router = express.Router()
 var db = require('../db/index.js')
 
+router.get('/', function (req,res) {
+    res.send('works for me');
+})
 
 router.get('/test', function(req,res) {
     const query = 'Select * from users';

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,11 +2,11 @@ var express = require('express')
 var router = express.Router()
 var db = require('../db/index.js')
 
-router.get('/', function (req,res) {
+router.get('/test', function (req,res) {
     res.send('works for me');
 })
 
-router.get('/test', function(req,res) {
+router.get('/test-db', function(req,res) {
     const query = 'Select * from users';
     db.query(query)
     .then(results => {

--- a/start.js
+++ b/start.js
@@ -12,9 +12,8 @@ const port = process.env.PORT || 8080
 
 var index_router = require('./routes/index.js')
 
-// Leave out react stuff for heroku black triangle
-// // Serve the static files from the React app
-// app.use(express.static(path.join(__dirname, 'client/build')));
+// Serve the static files from the React app
+app.use(express.static(path.join(__dirname, 'client/build')));
 
 app.use('/', index_router)
 
@@ -24,6 +23,4 @@ app.get('*', (req,res) =>{
 });
 
 
-// app.get('/', (req, res) => res.send('Hello World!'))
-
-app.listen(port, () => console.log(`Example app listening at http://localhost:${port}`))
+app.listen(port, () => console.log(`Express app listening at http://localhost:${port}`))

--- a/start.js
+++ b/start.js
@@ -7,7 +7,7 @@ const express = require('express')
 const path = require('path');
 
 const app = express()
-const port = process.env.PORT || 3000
+const port = process.env.PORT || 8080
 
 
 var index_router = require('./routes/index.js')

--- a/start.js
+++ b/start.js
@@ -7,13 +7,14 @@ const express = require('express')
 const path = require('path');
 
 const app = express()
-const port = 3000
+const port = process.env.PORT || 3000
 
 
 var index_router = require('./routes/index.js')
 
-// Serve the static files from the React app
-app.use(express.static(path.join(__dirname, 'client/build')));
+// Leave out react stuff for heroku black triangle
+// // Serve the static files from the React app
+// app.use(express.static(path.join(__dirname, 'client/build')));
 
 app.use('/', index_router)
 


### PR DESCRIPTION
Allows use of `create-react-app` dev server for hot reloading, while still making custom express server work in production. 

It works by setting the express server PORT to 8080 rather than 3000 (which is the default port for the hot reloading server) and then adding a "proxy" link in the `client/package.json` to forward any API calls to the express server. 

*To use hot reloading while developing locally, you'll need to run two different terminal processes*
1) npm start    (runs the hot reloading react)
2) npm run server      (runs the API server)

Builds on previous branch `heroku-triangle` to fix basic Heroku bugs 