### PR TITLE
Add routes tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,10 @@ const apiRouter = require('./routes/api.js')
 const app = express()
 
 // Log all HTTP requests
-app.use(morgan('dev'))
+// (Disable logs when running tests)
+if (process.env.NODE_ENV !== 'test') {
+  app.use(morgan('dev'))
+}
 
 // Serve the static files from the React app
 app.use(express.static(path.join(__dirname, 'client/build')))

--- a/package.json
+++ b/package.json
@@ -47,6 +47,13 @@
     "ignore": [
       "client/build"
     ],
-  "globals": [ "describe", "it", "before", "beforeEach", "afterEach", "after" ]
+    "globals": [
+      "describe",
+      "it",
+      "before",
+      "beforeEach",
+      "afterEach",
+      "after"
+    ]
   }
 }

--- a/routes/api.js
+++ b/routes/api.js
@@ -10,7 +10,6 @@ api.use(bodyParser.json())
 api.post('/users', async function (req, res) {
   const { firstName, lastName, email } = req.body
   if (!firstName || !lastName || !email) {
-    console.log('Input field empty')
     return res.status(400).send('Input field empty')
   }
   UserService.signup(firstName, lastName, email)

--- a/tests/integration/models.test.js
+++ b/tests/integration/models.test.js
@@ -1,12 +1,7 @@
 const { expect } = require('chai')
 
 const UserModel = require('../../models/users')
-const db = require('../../db')
-
-async function deleteAllUsers () {
-  const deleteAllUsers = { text: 'DELETE FROM users' }
-  await db.query(deleteAllUsers)
-}
+const { deleteAllUsers } = require('./utils')
 
 describe('UserModel', function () {
   let mockFirstName, mockLastName, mockEmail, mockSecret

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest')
+const { expect } = require('chai')
+const app = require('../../app')
+const { deleteAllUsers } = require('./utils')
+
+// Helpful links for writing new route integration tests
+// - https://github.com/visionmedia/supertest#example
+// - https://mochajs.org/#asynchronous-code
+
+describe('API Routes', function () {
+  describe('POST /api/users', function () {
+    let mockUser
+    beforeEach(function () {
+      mockUser = {
+        firstName: 'mockFirstName',
+        lastName: 'mockLastName',
+        email: 'mockEmail'
+      }
+    })
+
+    afterEach(async function () {
+      await deleteAllUsers()
+    })
+
+    it('should 400 when required input is missing', function (done) {
+      request(app)
+        .post('/api/users')
+        .send({})
+        .expect(400, done)
+    })
+    it('should 201 + return secret on success', function (done) {
+      request(app)
+        .post('/api/users')
+        .send(mockUser)
+        .expect(201)
+        .then(response => {
+          expect(response.body).to.have.keys(['secret'])
+          done()
+        }).catch(err => done(err))
+    })
+  })
+
+  describe.skip('GET /api/users/:secret', function () {
+
+  })
+})
+
+describe.skip('Non-API routes', function () {
+
+})

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -1,0 +1,10 @@
+const db = require('../../db')
+
+async function deleteAllUsers () {
+  const deleteAllUsers = { text: 'DELETE FROM users' }
+  await db.query(deleteAllUsers)
+}
+
+module.exports = {
+  deleteAllUsers
+}


### PR DESCRIPTION
Adding route integration tests using [supertest](https://github.com/visionmedia/supertest)

### These tests could be a bit better

eg when testing `POST /users`, we might want to check that `UserModel.create` wasn't called and/or the database is still empty

but this would be extra work using `proxyquire` and `sinon` which is perhaps too complicated at this point.