### PR TITLE
moved alerts to separate file

### DIFF
--- a/client/src/AddFriend.js
+++ b/client/src/AddFriend.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import axios from 'axios'
-import { Button, Spinner, Alert } from 'react-bootstrap'
+import { Button, Spinner } from 'react-bootstrap'
 import 'bootstrap/dist/css/bootstrap.min.css'
 
 import CountDisplay from './CountDisplay'
 import DeleteButton from './DeleteButton'
+import FormAlert from './FormAlert'
+import { alertTable } from './constants'
 
 class AddFriend extends React.Component {
   constructor (props) {
@@ -18,10 +20,11 @@ class AddFriend extends React.Component {
       friendLName: '',
       friendEmail: '',
       isLoading: false,
-      status: 0
+      alertType: ''
     }
     this.handleAdd = this.handleAdd.bind(this)
     this.handleChange = this.handleChange.bind(this)
+    this.resetForm = this.resetForm.bind(this)
   }
 
   componentDidMount () {
@@ -39,34 +42,39 @@ class AddFriend extends React.Component {
       })
   }
 
+  // TODO: prevent page reload on empty input
   handleAdd (e) {
     // check for empty inputs
     this.setState({ isLoading: true })
     if (!this.state.friendFName || !this.state.friendLName || !this.state.friendEmail) {
-      return this.setState({ status: 406 })
+      return this.setState({ alertType: alertTable.EMPTY_FIELD })
     }
     axios.post('/api/friendships', this.state)
       .then(res => {
         console.log('got to axios.post')
         if (res.status >= 200 && res.status < 300) {
-          this.setState(state => {
-            const friendships = state.friendships.concat(state.friendFName + ' ' + state.friendLName)
-            const status = 201
-            return { friendships, status }
+          this.setState({
+            friendships: this.state.friendships.concat(this.state.friendFName + ' ' + this.state.friendLName),
+            alertType: alertTable.CREATED
           })
+          this.resetForm()
         }
+
+        // This seems to be clearing the friend name before alert can pass the data into alert component.
         this.setState({ isLoading: false })
       })
       .catch(err => {
         if (err.response.status === 409) {
-          this.setState({ status: 409 })
+          this.setState({ alertType: alertTable.FRIEND_EXISTS, isLoading: false })
+          this.resetForm()
         }
-        this.setState({ isLoading: false })
         console.log(err)
       })
     e.preventDefault()
     e.target.reset()
   }
+
+  resetForm () { this.setState({ friendFName: '', friendLName: '', friendEmail: '' }) }
 
   handleChange (e) {
     // handles changes to add friend inputs
@@ -112,9 +120,7 @@ class AddFriend extends React.Component {
           {this.state.isLoading ? loadButton() : submitButton()}
         </form>
 
-        <div>
-          {displayAlert(this.state)}
-        </div>
+        <FormAlert alertType={this.state.alertType} firstName={this.state.friendFName} lastName={this.state.friendFName} />
 
         <CountDisplay location={this.props.location} />
 
@@ -146,29 +152,6 @@ function submitButton () {
   return (
     <input type='submit' value='Add Friend' />
   )
-}
-
-// TODO: Set a 2 second timer to display alert before it disapears
-function displayAlert (state) {
-  if (state.status === 409) {
-    return (
-      <Alert variant='danger'>
-      You are already friends with this person.
-      </Alert>
-    )
-  } else if (state.status === 406) {
-    return (
-      <Alert variant='warning'>
-      Please fill all fields.
-      </Alert>
-    )
-  } else if (state.status === 201) {
-    return (
-      <Alert variant='success'>
-      You are now friends with {state.friendFName} {state.friendLName}
-      </Alert>
-    )
-  }
 }
 
 export default AddFriend

--- a/client/src/FormAlert.js
+++ b/client/src/FormAlert.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Alert } from 'react-bootstrap'
+import { alertTable } from './constants'
+
+class Alerts extends React.Component {
+  render () {
+    return (
+      <div>
+        {displayAlert(this.props.alertType, this.props.firstName, this.props.lastName)}
+      </div>
+    )
+  }
+}
+
+// TODO: Set a 2 second timer to display alert before it disapears
+function displayAlert (alertType, firstName, lastName) {
+  if (alertType === alertTable.FRIEND_EXISTS) {
+    return (
+      <Alert variant='danger'>
+      You are already friends with this person.
+      </Alert>
+    )
+  } else if (alertType === alertTable.EMPTY_FIELD) {
+    return (
+      <Alert variant='warning'>
+      Please fill all fields.
+      </Alert>
+    )
+  } else if (alertType === alertTable.CREATED) {
+    return (
+      <Alert variant='success'>
+      You are now friends with {firstName} {lastName}
+      </Alert>
+    )
+  }
+}
+export default Alerts

--- a/client/src/Login.js
+++ b/client/src/Login.js
@@ -1,13 +1,17 @@
 import React from 'react'
 import axios from 'axios'
 
+import SignupAlert from './SignupAlert'
+import { alertTable } from './constants'
+
 class Login extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
       firstName: '',
       lastName: '',
-      email: ''
+      email: '',
+      alertType: ''
     }
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleChange = this.handleChange.bind(this)
@@ -15,7 +19,7 @@ class Login extends React.Component {
 
   handleSubmit (e) {
     if (!this.state.firstName || !this.state.lastName || !this.state.email) {
-      return window.alert('Input field empty')
+      return this.setState({ alertType: alertTable.EMPTY_FIELD })
     }
     axios.post('/api/users', this.state)
       .then(res => {
@@ -28,7 +32,7 @@ class Login extends React.Component {
       })
       .catch(err => {
         if (err.response.status === 409) {
-          window.alert('You have already created an account with this email! Please check your email to login.')
+          return this.setState({ alertType: alertTable.DUPLICATE_ACCOUNT })
         }
       })
     e.preventDefault()
@@ -71,6 +75,7 @@ class Login extends React.Component {
           <input type='submit' value='Submit' />
 
         </form>
+        <SignupAlert alertType={this.state.alertType} />
       </div>
     )
   }

--- a/client/src/SignupAlert.js
+++ b/client/src/SignupAlert.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Alert } from 'react-bootstrap'
+import { alertTable } from './constants'
+
+class Alerts extends React.Component {
+  render () {
+    return (
+      <div>
+        {displayAlert(this.props.alertType)}
+      </div>
+    )
+  }
+}
+
+// TODO: Set a 2 second timer to display alert before it disapears
+function displayAlert (alertType) {
+  if (alertType === alertTable.DUPLICATE_ACCOUNT) {
+    return (
+      <Alert variant='danger'>
+      You have already created an account with this email! Please check your email to login.
+      </Alert>
+    )
+  } else if (alertType === alertTable.EMPTY_FIELD) {
+    return (
+      <Alert variant='warning'>
+      Please fill all fields.
+      </Alert>
+    )
+  }
+}
+export default Alerts

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,0 +1,8 @@
+module.exports = {
+  alertTable: {
+    EMPTY_FIELD: 'EMPTY_FIELD',
+    CREATED: 'CREATED',
+    FRIEND_EXISTS: 'FRIEND_EXISTS',
+    DUPLICATE_ACCOUNT: 'DUPLICATE_ACCOUNT'
+  }
+}


### PR DESCRIPTION
### This PR fixed bug when adding friends and other nits

- Problem: Adding a friend who was not a user only creates a new user
  - Fix: on `addFriend` in services.users.js, returning `friendId` stops execution and does not add friend. Removed return. 
- Problem: Submitting a friend and clicking submit again shows green alert instead of yellow empty input alert.
  - Fix: While input boxes may seem to have been cleared, the state still retains its data. Uses `setState` to manually set friend info to `' '` on click. 

#### Nits:
- Moved alerts to separate file
- Added alerts to Login page instead of using `windows.alert`