### PR TITLE
Adding a friend with a merged account, will add the friends parent account

### DIFF
--- a/client/src/AddFriend/AddFriend.js
+++ b/client/src/AddFriend/AddFriend.js
@@ -76,7 +76,7 @@ class AddFriend extends React.Component {
       this.resetForm(e)
     } catch (err) {
       console.log(err)
-      if (err.status === 409) {
+      if (err.response.status === 409) {
         this.setState({ alertType: alertTable.FRIEND_EXISTS })
       }
     }

--- a/client/src/AddFriend/RemoveFriendButton.js
+++ b/client/src/AddFriend/RemoveFriendButton.js
@@ -17,7 +17,7 @@ class RemoveFriendButton extends React.Component {
       .catch(err => {
         console.log(err)
       })
-    this.handleClose()
+    this.setState({ showDelete: false })
   }
 
   render () {

--- a/models/users.js
+++ b/models/users.js
@@ -224,7 +224,7 @@ module.exports = {
     const getUserSecret = {
       text: 'SELECT u2.secret FROM users u1 ' +
       'JOIN users u2 ON u1.mergeduserid = u2.id ' +
-      'WHERE u1.secret= $1',
+      'WHERE u1.secret = $1',
       values: [secret]
     }
     const userSecret = await db.query(getUserSecret)
@@ -232,6 +232,24 @@ module.exports = {
       return secret
     }
     return userSecret.rows[0].secret
+  },
+
+  getTrueUserEmailByEmail: async function (email) {
+    const userExists = await this.getUserIdByEmail(email)
+    if (!userExists) {
+      return null
+    }
+    const getUserEmail = {
+      text: 'SELECT u2.email FROM users u1 ' +
+      'JOIN users u2 ON u1.mergeduserid = u2.id ' +
+      'WHERE u1.email = $1',
+      values: [email]
+    }
+    const userEmail = await db.query(getUserEmail)
+    if (userEmail.rows.length === 0) {
+      return email
+    }
+    return userEmail.rows[0].email
   },
 
   getUserEmailBySecret: async function (secret) {

--- a/services/users.js
+++ b/services/users.js
@@ -30,11 +30,14 @@ async function login (secret) {
 
 // TODO: refactor this so it makes more sense
 async function addFriend (userId, firstName, lastName, friendFName, friendLName, friendEmail) {
+  // If merged account, get trueFriendEmail of from friend email. Otherwise, getTrueUserEmailByEmail returns friendEmail
+  const trueFriendEmail = await UserModel.getTrueUserEmailByEmail(friendEmail)
+
   // Get userId of friend
   let friendId
-  const userExists = await checkEmailAlreadyRegistered(friendEmail)
+  const userExists = await checkEmailAlreadyRegistered(trueFriendEmail)
   if (userExists) {
-    friendId = await UserModel.getUserIdByEmail(friendEmail)
+    friendId = await UserModel.getUserIdByEmail(trueFriendEmail)
   } else {
     const secret = uuidv4()
     friendId = await UserModel.create(friendFName, friendLName, friendEmail, secret)
@@ -44,7 +47,7 @@ async function addFriend (userId, firstName, lastName, friendFName, friendLName,
 
   // Add friend
   if (userExists) {
-    const friendshipExists = await UserModel.checkFriendshipExists(userId, friendEmail)
+    const friendshipExists = await UserModel.checkFriendshipExists(userId, trueFriendEmail)
     if (friendshipExists) {
       throw new Error('friendshipExists')
     }


### PR DESCRIPTION
- Made changes to `addFriend` in user services. Added a `getTrueUserEmailByEmail` that returns a parent email or the email passed as a parameter if no parent email is found. 
- Small bug fixes.